### PR TITLE
Heroku 배포를 위한 파일 추가 및 수정

### DIFF
--- a/Cookie_Box/settings.py
+++ b/Cookie_Box/settings.py
@@ -25,7 +25,7 @@ def get_secret(setting, secrets=secrets):
 SECRET_KEY = get_secret("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = bool(os.environ.get('DJANGO_DEBUG', True))
 
 ALLOWED_HOSTS = []
 
@@ -64,6 +64,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
 ]
 
 ROOT_URLCONF = 'Cookie_Box.urls'
@@ -182,3 +183,12 @@ EMAIL_PORT = int(get_email_info("EMAIL_PORT"))
 EMAIL_HOST_USER = get_email_info("EMAIL_HOST_USER")
 EMAIL_HOST_PASSWORD = get_email_info("EMAIL_HOST_PASSWORD")
 EMAIL_USE_TLS = True
+
+# Heroku : Update database configuration from $DATABASE_URL
+import dj_database_url
+db_from_env = dj_database_url.config(conn_max_age=500)
+DATABASES['default'].update(db_from_env)
+
+# Heroku 운영환경에서 정적 파일을 관리하기 위해 Whienoise를 사용하는데, 이를 통해 정적파일의 크기를 줄일 수 있다.
+# https://warehouse.python.org/project/whitenoise/
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web : gunicorn cookiebox.wsgi --log-file -

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,5 @@ sqlparse==0.3.1
 text-unidecode==1.3
 whitenoise==5.2.0
 yapf==0.30.0
-psycopg2==2.6.2
+psycopg2==2.8.6
+psycopg2-binary==2.8.6

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,0 +1,3 @@
+# runtime.txt
+
+Python-3.8.3


### PR DESCRIPTION
1. settings.py
 - 운영환경에서 DEBUG가 False로 설정되도록 수정
 - WhiteNoise 설정 추가
 - dj-database-url (환경변수를 통한 Django DB 설정)를 사용하기 위한 설정 추가

2. Procfile
 : 애플리케이션에 어떤 커맨드가 실행되어야 하는지 선언하는 파일

3. requirements.txt
 - psycopg2, psycopg2-binary 패키지 추가

4. runtime.txt
 - Heroku에게 애플리케이션의 개발언어를 알려주는 파일